### PR TITLE
Fix http2 not supported

### DIFF
--- a/config/dev/haproxy_develop.cfg
+++ b/config/dev/haproxy_develop.cfg
@@ -26,11 +26,11 @@ global
 
 defaults
 
-    log    global
-    backlog 10000
-    option    contstats
-    option    dontlognull
-    option    redispatch
+    log        global
+    backlog    10000
+    option     contstats
+    option     dontlognull
+    option     redispatch
     retries    3
     timeout    tunnel            3600s
     timeout    queue            30s
@@ -62,7 +62,7 @@ frontend ha-frontend-http
     mode    http
     option  httplog
     option  http-server-close
-    bind    :443 ssl crt /etc/ssl/private/proxy.pem alpn h2,http/1.1
+    bind    :443 ssl crt /etc/ssl/private/proxy.pem
     bind    :80
     redirect scheme https code 301 if !{ ssl_fc }
 

--- a/config/qa/haproxy_qa.cfg
+++ b/config/qa/haproxy_qa.cfg
@@ -61,7 +61,7 @@ frontend ha-frontend-http
     mode    http
     option  httplog
     option  http-server-close
-    bind    :443 ssl crt /etc/ssl/private/proxy.pem alpn h2,http/1.1
+    bind    :443 ssl crt /etc/ssl/private/proxy.pem
     bind    :80
     redirect scheme https code 301 if !{ ssl_fc }
 

--- a/config/release/haproxy_release.cfg
+++ b/config/release/haproxy_release.cfg
@@ -61,7 +61,7 @@ frontend ha-frontend-http
     mode    http
     option  httplog
     option  http-server-close
-    bind    :443 ssl crt /etc/ssl/private/proxy.pem alpn h2,http/1.1
+    bind    :443 ssl crt /etc/ssl/private/proxy.pem
     bind    :80
     redirect scheme https code 301 if !{ ssl_fc }
 


### PR DESCRIPTION
Fix http2 support regression
---
Default parameter from https://ssl-config.mozilla.org/#server=haproxy are adding `alpn h2,http/1.1` that needs also to be supported on backend.
Doc here:
https://www.haproxy.com/documentation/hapee/latest/load-balancing/protocols/http-2/