### PR TITLE
fix the add-header's in the configurations

### DIFF
--- a/config/dev/haproxy_develop.cfg
+++ b/config/dev/haproxy_develop.cfg
@@ -139,6 +139,7 @@ frontend ha-frontend-spawner
 backend ha-backend-monitoring
 	mode http
 	server container-monitoring 127.0.0.1 disabled
+	http-response add-header X-Frame-Options SAMEORIGIN
 
 backend ha-backend-http
 	mode http
@@ -163,8 +164,8 @@ backend ha-backend-redis-slave
 backend ha-backend-ros-tools
 	mode http
 	server container-ros-tools 127.0.0.1 disabled
-	http-response add-header X-Content-Type-Options: nosniff
-	http-response add-header X-Frame-Options: deny
+	http-response add-header X-Content-Type-Options nosniff
+	http-response add-header X-Frame-Options deny
 
 backend ha-backend-spawner
 	mode tcp

--- a/config/qa/haproxy_qa.cfg
+++ b/config/qa/haproxy_qa.cfg
@@ -139,7 +139,7 @@ backend ha-backend-monitoring
 backend ha-backend-http
 	mode http
 	server container-backend 127.0.0.1 disabled
-	http-response add-header X-Frame-Options: SAMEORIGIN
+	http-response add-header X-Frame-Options SAMEORIGIN
 
 backend ha-backend-npm
 	mode http
@@ -158,8 +158,8 @@ backend ha-backend-redis-slave
 backend ha-backend-ros-tools
 	mode http
 	server container-ros-tools 127.0.0.1 disabled
-	http-response add-header X-Content-Type-Options: nosniff
-	http-response add-header X-Frame-Options: deny
+	http-response add-header X-Content-Type-Options nosniff
+	http-response add-header X-Frame-Options deny
 
 backend ha-backend-spawner
 	mode tcp

--- a/config/release/haproxy_release.cfg
+++ b/config/release/haproxy_release.cfg
@@ -125,7 +125,7 @@ backend ha-backend-monitoring
 backend ha-backend-http
 	mode http
 	server container-backend 127.0.0.1 disabled
-	http-response add-header X-Frame-Options: SAMEORIGIN
+	http-response add-header X-Frame-Options SAMEORIGIN
 
 backend ha-backend-redis-master
 	mode tcp


### PR DESCRIPTION
Fixed the add of headers in the configurations which had the incorrect syntaxes.
One of the headers that was suposed to be added is the fix for this security issue.

The solution was tested through iframing our frontend apps like sugested in this article:
https://owasp.org/www-project-web-security-testing-guide/v41/4-Web_Application_Security_Testing/11-Client_Side_Testing/09-Testing_for_Clickjacking

The fix was done manually in redhat manager to test remotly iframing, and worked. Still waiting for @almeidamov  qualys run status. Luis please update the status here in the PR.

PS: yes, took advantage since i was fixing one header, i fixed others also.