### PR TITLE
DP-819 protect ros-tools apps

### DIFF
--- a/config/dev/haproxy_develop.cfg
+++ b/config/dev/haproxy_develop.cfg
@@ -161,7 +161,7 @@ backend ha-backend-ros-tools
     mode http
     server container-ros-tools 127.0.0.1 disabled
     http-response add-header X-Content-Type-Options nosniff
-    http-response add-header X-Frame-Options deny
+    http-response add-header X-Frame-Options SAMEORIGIN
 
 backend ha-backend-spawner
     mode tcp

--- a/config/qa/haproxy_qa.cfg
+++ b/config/qa/haproxy_qa.cfg
@@ -150,7 +150,7 @@ backend ha-backend-ros-tools
     mode http
     server container-ros-tools 127.0.0.1 disabled
     http-response add-header X-Content-Type-Options nosniff
-    http-response add-header X-Frame-Options deny
+    http-response add-header X-Frame-Options SAMEORIGIN
 
 backend ha-backend-spawner
     mode tcp


### PR DESCRIPTION
Tested in redhat manager and the rostools were unframable. 
those were the pages qualys found problematic. 

@AlexFernandes-MOVAI the release config does not contain rostools (im imagining its not suposed to be avaiable on clients). But still if it was found is because its being accessed. Ill add this also on ansible. 