### PR TITLE
DP-1380: expose influxDB behind same authentication as monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,13 @@
     - ha-backend-redis-master : redis-master container
     - ha-backend-redis-slave : redis-slave container
     - ha-backend-spawner : spawner container
-    - ha-backend-ros-tools : ros-tools container
+    - ha-backend-ros-tools : ros-tools container (`/ros-tools`)
     - ha-backend-ros-master : ros-master container
+    - ha-backend-influxdb : influxdb container (`/influxdb`)
 
 
 - Enabled static frontends:
-  - ha-frontend-http : http, 80 and 443, ssl
+  - ha-frontend-http : http, 80 and 443, ssl (`/monitoring` and `/influxdb` need authentication)
   - ha-frontend-redis-master : tcp 6379, ssl (outer interface)
   - ha-frontend-redis-slave : tcp 6379 (inner network)
   - ha-frontend-spawner : tcp, dynamic ports FMT_PORTS
@@ -36,6 +37,24 @@
 - Certificates generation for frontends that use SSL (http, redis-master, ros-tools) see [Certificates](#certificates) for more information
 
 - Certificates verification for frontends that use SSL (http, redis-master, ros-tools) see [Certificates verification](#certificates-verification) for more information
+
+- Authentication is required for the `/monitoring` and `/influxdb` paths in the `ha-frontend-http` frontend.
+
+
+## Authenticated users
+
+The `ha-frontend-http` frontend requires authentication for the `/monitoring` and `/influxdb` paths.
+The username and password are set in the `haproxy.cfg` file and are `admin` and `admin123` respectively.
+
+- To add more users dynamically to this group, the `haproxy.cfg` file can be updated with the new user's credentials.
+  Passwords should be hashed using the `mkpasswd` command as follows:
+
+```bash
+mkpasswd -m sha-256 <password>
+```
+
+- To remove a user from the group, the `haproxy.cfg` file can be updated to remove the user.
+- The `haproxy.cfg` file should be updated with the new user's credentials and the container should be restarted to apply the changes.
 
 ## Certificates
 

--- a/config/dev/haproxy_develop.cfg
+++ b/config/dev/haproxy_develop.cfg
@@ -81,12 +81,24 @@ frontend ha-frontend-http
     # http-request capture req.hdr(Origin) len 256
     # http-request lua.cors "*" "*" "*"
 
+    redirect scheme https code 301 if !{ ssl_fc }
+
     # Monitoring authenticated ACL
     acl PATH_monitoring path_beg -i /monitoring
     acl is_authusers_acl http_auth(AuthUsers)
     http-request auth realm ha-backend-monitoring if PATH_monitoring !is_authusers_acl
+    use_backend ha-backend-monitoring if { path -i -m beg /monitoring }
 
-    redirect scheme https code 301 if !{ ssl_fc }
+    # InfluxDB authenticated ACL
+    acl PATH_influxdb path_beg -i /influxdb
+    acl is_authusers_acl http_auth(AuthUsers)
+    http-request auth realm ha-backend-influxdb if PATH_influxdb !is_authusers_acl
+    use_backend ha-backend-influxdb if { path -i -m beg /influxdb }
+
+    # Ros Tools rewriting ACL
+    acl url_ros-tools path_beg -i /ros-tools
+    acl url_ros-tools_websockify path_beg -i /websockify
+    use_backend ha-backend-ros-tools if url_ros-tools or url_ros-tools_websockify
 
     # Remove CORS response headers
     # http-response del-header access-control-expose-headers
@@ -106,7 +118,7 @@ frontend ha-frontend-http
 
     # Health-node non-authenticated ACL
     use_backend ha-backend-health-node if { path -i -m beg /health }
-    use_backend ha-backend-monitoring if { path -i -m beg /monitoring }
+
 
     # Added stats support
     stats enable
@@ -231,6 +243,7 @@ backend ha-backend-ros-tools
     mode http
     default-server maxconn 20
     server container-ros-tools 127.0.0.1:6901 disabled
+    http-request replace-path ^/ros-tools/(.*) /\1
 
 backend ha-backend-ros-master
     mode http
@@ -242,4 +255,10 @@ backend ha-backend-health-node
     default-server maxconn 2000
     http-request set-path "%[path,regsub(^/health/?,/)]"
     server container-health-node 127.0.0.1 disabled
+
+backend ha-backend-influxdb
+    mode http
+    default-server maxconn 2000
+    server container-influxdb 127.0.0.1 disabled
+    http-request replace-path ^/influxdb/(.*) /\1
 

--- a/config/qa/haproxy_qa.cfg
+++ b/config/qa/haproxy_qa.cfg
@@ -89,6 +89,12 @@ frontend ha-frontend-http
     http-request auth realm ha-backend-monitoring if PATH_monitoring !is_authusers_acl
     use_backend ha-backend-monitoring if { path -i -m beg /monitoring }
 
+    # InfluxDB authenticated ACL
+    acl PATH_influxdb path_beg -i /influxdb
+    acl is_authusers_acl http_auth(AuthUsers)
+    http-request auth realm ha-backend-influxdb if PATH_influxdb !is_authusers_acl
+    use_backend ha-backend-influxdb if { path -i -m beg /influxdb }
+
     # Ros Tools rewriting ACL
     acl url_ros-tools path_beg -i /ros-tools
     acl url_ros-tools_websockify path_beg -i /websockify
@@ -232,4 +238,10 @@ backend ha-backend-health-node
     default-server maxconn 2000
     http-request set-path "%[path,regsub(^/health/?,/)]"
     server container-health-node 127.0.0.1 disabled
+
+backend ha-backend-influxdb
+    mode http
+    default-server maxconn 2000
+    server container-influxdb 127.0.0.1 disabled
+    http-request replace-path ^/influxdb/(.*) /\1
 

--- a/config/release/haproxy_release.cfg
+++ b/config/release/haproxy_release.cfg
@@ -89,6 +89,12 @@ frontend ha-frontend-http
     http-request auth realm ha-backend-monitoring if PATH_monitoring !is_authusers_acl
     use_backend ha-backend-monitoring if { path -i -m beg /monitoring }
 
+    # InfluxDB authenticated ACL
+    acl PATH_influxdb path_beg -i /influxdb
+    acl is_authusers_acl http_auth(AuthUsers)
+    http-request auth realm ha-backend-influxdb if PATH_influxdb !is_authusers_acl
+    use_backend ha-backend-influxdb if { path -i -m beg /influxdb }
+
     # Ros Tools rewriting ACL
     acl url_ros-tools path_beg -i /ros-tools
     acl url_ros-tools_websockify path_beg -i /websockify
@@ -223,4 +229,10 @@ backend ha-backend-health-node
     default-server maxconn 2000
     http-request set-path "%[path,regsub(^/health/?,/)]"
     server container-health-node 127.0.0.1 disabled
+
+backend ha-backend-influxdb
+    mode http
+    default-server maxconn 2000
+    server container-influxdb 127.0.0.1 disabled
+    http-request replace-path ^/influxdb/(.*) /\1
 


### PR DESCRIPTION
DP-1380: expose influxDB behind same authentication as monitoring (EE 2.3.1)

### Content
- update of Documentation with latest additions
- align all configuration files of develop / qa / release environment
- 

### Test influxdb API access:
- build and tag the docker image
- use it in a running robot
- `curl "https://admin:admin123@localhost/influxdb/query?q=SHOW+
DATABASES" -k`