### PR TITLE
DP-1781: fix entrypoint syntax issues

### DIFF
--- a/common_files/movai-entrypoint.sh
+++ b/common_files/movai-entrypoint.sh
@@ -25,18 +25,20 @@ ROS_TOOLS_VERIFY="false"
 # else
 
 # Generate the certificates
-if [ ! -f "/etc/ssl/private/proxy.pem" ]; then
+if [ ! -f "/etc/ssl/private/proxy.pem" ] && [ ! -f "/etc/ssl/certs/proxy.pem" ]; then
     GEN_CERT_OPTS=""
     if [ -n "${PUBLIC_IP}" ]; then
         CN_ARG="${PUBLIC_IP}"
-        GEN_CERT_OPTS="${GEN_CERT_OPTS} --cn ${CN_ARG}"
+        GEN_CERT_OPTS="${GEN_CERT_OPTS} --cn=${CN_ARG}"
     fi
 
     if [ -n "${DNS_ALT_NAMES}" ]; then
         ALT_NAMES_ARG="${DNS_ALT_NAMES}"
-        GEN_CERT_OPTS="${GEN_CERT_OPTS} --alt_names ${ALT_NAMES_ARG}"
+        GEN_CERT_OPTS="${GEN_CERT_OPTS} --alt_names=${ALT_NAMES_ARG}"
     fi
     /usr/local/etc/haproxy/gen_cert.sh ${GEN_CERT_OPTS}
+else
+    printf "Certificate already exists, skipping generation\n"
 fi
 
 test -z "${SPAWNER_PORTS}" && SPAWNER_PORTS='disabled'


### PR DESCRIPTION
Fix syntax issues on calling gen_cert.sh

```
Error: Unknown option: --cn

Error: Unknown option: 127.0.0.1
```

Tested OK onEE [2.3.1-91](https://github.com/MOV-AI/ee-project-platform/releases/tag/2.3.1-91) with and without pre-generated certificate

---

- [x] Make sure you are opening from a **topic/feature/bugfix branch**
- [x] Ensure that the PR title represents the desired changes
- [x] Ensure that the PR description detail the desired changes
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
